### PR TITLE
Remove deprecated dependency on container-interop

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "psr/http-message": "^1.0",
         "http-interop/http-server-handler": "^1.0",
         "http-interop/http-server-middleware": "^1.0",
-        "container-interop/container-interop": "^1.1",
+        "psr/container": "^1.0",
         "mindplay/readable": "^1"
     },
     "require-dev": {

--- a/src/ContainerResolver.php
+++ b/src/ContainerResolver.php
@@ -2,7 +2,7 @@
 
 namespace mindplay\middleman;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use RuntimeException;
 
 /**

--- a/test/test.php
+++ b/test/test.php
@@ -1,11 +1,11 @@
 <?php
 
-use Interop\Container\ContainerInterface;
 use Interop\Http\Server\MiddlewareInterface;
 use Interop\Http\Server\RequestHandlerInterface;
 use mindplay\middleman\ContainerResolver;
 use mindplay\middleman\Dispatcher;
 use Mockery\MockInterface;
+use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 


### PR DESCRIPTION
Container-interop is an extension of the PSR-11 psr/container package. By depending on that interface, we cover more possible PSR-11 containers. Containers still implementing containter-interop remain untouched, as the interface is a mere extension of the psr-11 interface.