### PR TITLE
add support for PSR-15 RequestHandlerInterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $dispatcher = new Dispatcher([
     // ...
 ]);
 
-$response = $dispatcher->dispatch($request);
+$response = $dispatcher->handle($request);
 ```
 
 For simplicity, the middleware-stack in a `Dispatcher` is immutable - if you need a stack you can manipulate, `array`, `ArrayObject`, `SplStack` etc. are all fine choices.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,12 @@
 Upgrading
 =========
 
+### From 3.x to 3.1
+
+`Dispatcher::dispatch()` has been deprecated in favor of PSR-15 `RequestHandlerInterface::handle()`, which
+is now implemented by `Dispatcher` - the legacy `dispatch()` method is still supported for backwards
+compatibility, but you should switch to the identical PSR-15 standard `handle()` method instead.
+
 ### From 2.x to 3.x
 
 PSR-15 (as of `1.0`) requires PHP 7.0, which is now the minimum requirement for this package.

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -14,7 +14,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 /**
  * PSR-7 / PSR-15 middleware dispatcher
  */
-class Dispatcher implements LegacyMiddlewareInterface
+class Dispatcher implements LegacyMiddlewareInterface, RequestHandlerInterface
 {
     /**
      * @var callable middleware resolver
@@ -52,11 +52,27 @@ class Dispatcher implements LegacyMiddlewareInterface
      *
      * @throws LogicException on unexpected result from any middleware on the stack
      */
-    public function dispatch(ServerRequestInterface $request): ResponseInterface
+    public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $resolved = $this->resolve(0);
 
         return $resolved->handle($request);
+    }
+
+    /**
+     * Dispatches the middleware stack and returns the resulting `ResponseInterface`.
+     *
+     * @deprecated in favor of identical PSR-15 method `RequestHandlerInterface::handle()`
+     * 
+     * @param ServerRequestInterface $request
+     *
+     * @return ResponseInterface
+     *
+     * @throws LogicException on unexpected result from any middleware on the stack
+     */
+    public function dispatch(ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->handle($request);
     }
 
     /**

--- a/test/test.php
+++ b/test/test.php
@@ -58,7 +58,7 @@ test(
             'LogicException',
             'should throw for exhausted middleware stack',
             function () use ($dispatcher) {
-                $dispatcher->dispatch(mock_server_request());
+                $dispatcher->handle(mock_server_request());
             }
         );
     }
@@ -83,7 +83,7 @@ test(
             }
         ]);
 
-        $returned = $dispatcher->dispatch($request);
+        $returned = $dispatcher->handle($request);
 
         ok($called, 'the middleware was dispatched');
         ok($returned instanceof ResponseInterface, 'it returns the response');
@@ -110,7 +110,7 @@ test(
             }
         ]);
 
-        $returned = $dispatcher->dispatch(mock_server_request());
+        $returned = $dispatcher->handle(mock_server_request());
 
         ok($called_one === 1, 'the first middleware was dispatched');
         ok($called_two === 2, 'the second middleware was dispatched');
@@ -151,12 +151,12 @@ test(
             }
         );
 
-        $dispatcher->dispatch(mock_server_request());
+        $dispatcher->handle(mock_server_request());
 
         eq($called['one'], 1, 'the first middleware was dispatched (once)');
         eq($called['two'], 1, 'the second middleware was dispatched (once)');
 
-        $returned = $dispatcher->dispatch(mock_server_request());
+        $returned = $dispatcher->handle(mock_server_request());
 
         ok($returned instanceof ResponseInterface, 'it returned the response');
 
@@ -189,7 +189,7 @@ test(
             'LogicException',
             'should throw on wrong return-type',
             function () use ($dispatcher, $request) {
-                $dispatcher->dispatch($request);
+                $dispatcher->handle($request);
             }
         );
     }
@@ -238,7 +238,7 @@ test(
             $resolver
         );
 
-        $dispatcher->dispatch(mock_server_request());
+        $dispatcher->handle(mock_server_request());
 
         ok($called_indirect, 'middleware gets resolved via DI container and invoked');
         ok($called_direct, 'other middleware gets invoked directly');
@@ -251,7 +251,7 @@ test(
             'RuntimeException',
             'should throw for middleware that cannot be resolved',
             function () use ($dispatcher) {
-                $dispatcher->dispatch(mock_server_request());
+                $dispatcher->handle(mock_server_request());
             }
         );
     }
@@ -306,7 +306,7 @@ test(
             ]
         );
 
-        $response = $dispatcher->dispatch(mock_server_request());
+        $response = $dispatcher->handle(mock_server_request());
 
         eq($result, [1, 2, 3, 4], "executes nested middleware components in order");
 
@@ -337,7 +337,7 @@ test(
             new InvokableMiddleware(mock_response())
         ]);
 
-        ok($dispatcher->dispatch(mock_server_request()) instanceof ResponseInterface);
+        ok($dispatcher->handle(mock_server_request()) instanceof ResponseInterface);
     }
 );
 
@@ -364,7 +364,7 @@ test(
             new LegacyServerMiddleware(mock_response())
         ]);
 
-        ok($dispatcher->dispatch(mock_server_request()) instanceof ResponseInterface);
+        ok($dispatcher->handle(mock_server_request()) instanceof ResponseInterface);
     }
 );
 
@@ -391,7 +391,7 @@ test(
             new PSRServerMiddleware(mock_response())
         ]);
 
-        ok($dispatcher->dispatch(mock_server_request()) instanceof ResponseInterface);
+        ok($dispatcher->handle(mock_server_request()) instanceof ResponseInterface);
     }
 );
 


### PR DESCRIPTION
Deprecates the legacy `dispatch()` method in favor of PSR-15 standard `RequestHandlerInterface::handle()`

Closes #20