### PR TITLE
Preparing for milestone 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ script: php -d xdebug.mode=coverage test/test.php
 
 after_script:
   - if [ $(phpenv version-name) = "7.4" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi
-  - if [ $(phpenv version-name) = "7.4" ]; then php ocular.phar code-coverage:upload --format=php-clover test/build/clover.xml; fi
+  - if [ $(phpenv version-name) = "7.4" ]; then php ocular.phar code-coverage:upload --format=php-clover test/build/coverage.xml; fi

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ mindplay/middleman
 Dead simple PSR-15 / PSR-7 [middleware](#middleware) dispatcher.
 
 Provides (optional) integration with a [variety](https://github.com/container-interop/container-interop#compatible-projects)
-of dependency injection containers compliant with [container-interop](https://github.com/container-interop/container-interop).
+of dependency injection containers compliant with [PSR-11](https://www.php-fig.org/psr/psr-11/).
 
 To upgrade between major releases, please see [UPGRADING.md](UPGRADING.md).
 
@@ -50,7 +50,7 @@ class MyMiddleware implements MiddlewareInteface
 }
 ```
 
-If you want to integrate with a [DI container](https://github.com/container-interop/container-interop#compatible-projects)
+If you want to integrate with an [IOC container](https://github.com/container-interop/container-interop#compatible-projects)
 you can use the `ContainerResolver` - a "resolver" is a callable which gets applied to every element in your middleware stack,
 with a signature like:
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ mindplay/middleman
 Dead simple PSR-15 / PSR-7 [middleware](#middleware) dispatcher.
 
 Provides (optional) integration with a [variety](https://github.com/container-interop/container-interop#compatible-projects)
-of dependency injection containers compliant with [PSR-11](https://www.php-fig.org/psr/psr-11/).
+of dependency injection containers compatible with [PSR-11](https://www.php-fig.org/psr/psr-11/).
 
 To upgrade between major releases, please see [UPGRADING.md](UPGRADING.md).
 
@@ -15,18 +15,43 @@ To upgrade between major releases, please see [UPGRADING.md](UPGRADING.md).
 
 A growing catalog of PSR-15 middleware-components is available from [github.com/middlewares](https://github.com/middlewares).
 
-You can implement simple middleware "in place" by using anonymous functions in a middleware-stack:
+## Usage
+
+The constructor expects an array of PSR-15 `MiddlewareInterface` instances:
+
+```php
+use mindplay\middleman\Dispatcher;
+
+$dispatcher = new Dispatcher([
+    new ErrorHandlerMiddleware(...)
+    new RouterMiddleware(...),
+    new NotFoundMiddleware(...),
+]);
+```
+
+The `Dispatcher` implements the PSR-15 `RequestHandlerInterface`. This package *only* provides the
+middleware stack - to run a PSR-15 handler, for example in your `index.php` file, you need
+a [PSR-15 host](https://packagist.org/packages/mindplay/sapi-host) or a similar facility.
+
+Note that the middleware-stack in the `Dispatcher` is immutable - if you need a stack you can manipulate, `array`, `ArrayObject`, `SplStack` etc. are all fine choices.
+
+### Anonymous Functions as Middleware
+
+You can implement simple middleware "in place" by using anonymous functions in a middleware-stack, using a PSR-7/17 implementation such as [`nyholm/psr7`](https://packagist.org/packages/nyholm/psr7):
 
 ```php
 use Psr\Http\Message\ServerRequestInterface;
-use Zend\Diactoros\Response;
+use mindplay\middleman\Dispatcher;
+use Nyholm\Psr7\Factory\Psr17Factory;
+
+$factory = new Psr17Factory();
 
 $dispatcher = new Dispatcher([
     function (ServerRequestInterface $request, callable $next) {
         return $next($request); // delegate control to next middleware
     },
-    function (ServerRequestInterface $request) {
-        return (new Response())->withBody(...); // abort middleware stack and return the response
+    function (ServerRequestInterface $request) use ($factory) {
+        return $factory->createResponse(200)->withBody(...); // abort middleware stack and return the response
     },
     // ...
 ]);
@@ -34,21 +59,7 @@ $dispatcher = new Dispatcher([
 $response = $dispatcher->handle($request);
 ```
 
-For simplicity, the middleware-stack in a `Dispatcher` is immutable - if you need a stack you can manipulate, `array`, `ArrayObject`, `SplStack` etc. are all fine choices.
-
-To implement reusable middleware components, you should implement the [PSR-15](https://packagist.org/packages/psr/http-server-middleware) `MiddlewareInterface`.
-
-```php
-use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\ServerMiddleware\MiddlewareInterface;
-
-class MyMiddleware implements MiddlewareInteface
-{
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate) {
-        // ...
-    }
-}
-```
+### Dependency Injection via the Resolver Function
 
 If you want to integrate with an [IOC container](https://github.com/container-interop/container-interop#compatible-projects)
 you can use the `ContainerResolver` - a "resolver" is a callable which gets applied to every element in your middleware stack,
@@ -76,10 +87,8 @@ If you want to understand precisely how this component works, the whole thing is
 with a few lines of code](src/Dispatcher.php) - if you're going to base your next
 project on middleware, you can (and should) understand the whole mechanism.
 
------
-
 <a name="middleware"></a>
-### Middleware?
+## Middleware?
 
 Middleware is a powerful, yet simple control facility.
 
@@ -91,7 +100,7 @@ that takes an incoming (PSR-7) `RequestInterface` object, and returns a `Respons
 It does this in one of three ways: by *assuming*, *delegating*, or *sharing* responsibility
 for the creation of a response object.
 
-##### 1. Assuming Responsibility
+#### 1. Assuming Responsibility
 
 A middleware component *assumes* responsibility by creating and returning a response object,
 rather than delegating to the next middleware on the stack:
@@ -107,7 +116,7 @@ function ($request, $next) {
 Middleware near the top of the stack has the power to completely bypass middleware
 further down the stack.
 
-##### 2. Delegating Responsibility
+#### 2. Delegating Responsibility
 
 By calling `$next`, middleware near the top of the stack may choose to fully delegate the
 responsibility for the creation of a response to other middleware components
@@ -127,7 +136,7 @@ Note that exhausting the middleware stack will result in an exception - it's ass
 the last middleware component on the stack always produces a response of some sort, typically
 a "404 not found" error page.
 
-##### 3. Sharing Responsibility
+#### 3. Sharing Responsibility
 
 Middleware near the top of the stack may choose to delegate responsibility for the creation of
 the response to middleware further down the stack, and then make additional changes to

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,17 @@
 Upgrading
 =========
 
+### From 3.1 to 4.0
+
+`Dispatcher::dispatch()` has been removed in favor of PSR-15 `RequestHandlerInterface::handle()`, which
+is now implemented by `Dispatcher` - you should switch to the identical PSR-15 standard `handle()` method.
+
+Support for legacy PSR-15 middleware (`http-interop/http-server-middleware`) has been removed - please
+use the official, final `psr/http-server-middleware` package.
+
+Support for legacy PSR-11 IOC (`container-interop/container-interop`) has been removed - please use the
+official, final `psr/container` package.
+
 ### From 3.x to 3.1
 
 `Dispatcher::dispatch()` has been deprecated in favor of PSR-15 `RequestHandlerInterface::handle()`, which

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -9,8 +9,8 @@ is now implemented by `Dispatcher` - you should switch to the identical PSR-15 s
 Support for legacy PSR-15 middleware (`http-interop/http-server-middleware`) has been removed - please
 use the official, final `psr/http-server-middleware` package.
 
-Support for legacy PSR-11 IOC (`container-interop/container-interop`) has been removed - please use the
-official, final `psr/container` package.
+Support for legacy PSR-11 IOC containers (`container-interop/container-interop`) has been removed - please
+use the official, final `psr/container` package.
 
 ### From 3.x to 3.1
 

--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,12 @@
         "psr/http-message": "^1.0",
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0",
-        "http-interop/http-server-middleware": "^1.1.1",
         "psr/container": "^1.0",
         "mindplay/readable": "^1"
     },
     "require-dev": {
         "mindplay/testies": "^1.0",
         "phpunit/php-code-coverage": "^9.2.5",
-        "container-interop/container-interop": "^1.2",
         "nyholm/psr7": "^1.4"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,71 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8bcdb60c638303712b63d292bcffa3d0",
+    "content-hash": "a6dbc5dde3d66906b6413aa4f1e97ca9",
     "packages": [
-        {
-            "name": "http-interop/http-server-middleware",
-            "version": "1.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/http-interop/http-server-middleware.git",
-                "reference": "1ed99649e5f0d785c16d53cc021d7187ec350f28"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/http-interop/http-server-middleware/zipball/1ed99649e5f0d785c16d53cc021d7187ec350f28",
-                "reference": "1ed99649e5f0d785c16d53cc021d7187ec350f28",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.0",
-                "psr/http-message": "^1.0",
-                "psr/http-server-middleware": "^1.0"
-            },
-            "replace": {
-                "http-interop/http-middleware": ">=0.5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Interop\\Http\\Server\\": "src/"
-                },
-                "files": [
-                    "src/alias.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for HTTP server-side middleware",
-            "keywords": [
-                "http",
-                "middleware",
-                "psr",
-                "psr-15",
-                "psr-7",
-                "request",
-                "response"
-            ],
-            "support": {
-                "issues": "https://github.com/http-interop/http-server-middleware/issues",
-                "source": "https://github.com/http-interop/http-server-middleware/tree/master"
-            },
-            "abandoned": "psr/http-server-middleware",
-            "time": "2018-01-23T14:34:55+00:00"
-        },
         {
             "name": "mindplay/readable",
             "version": "1.1.2",
@@ -329,42 +266,6 @@
         }
     ],
     "packages-dev": [
-        {
-            "name": "container-interop/container-interop",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/container-interop/container-interop.git",
-                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
-                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
-                "shasum": ""
-            },
-            "require": {
-                "psr/container": "^1.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Interop\\Container\\": "src/Interop/Container/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
-            "homepage": "https://github.com/container-interop/container-interop",
-            "support": {
-                "issues": "https://github.com/container-interop/container-interop/issues",
-                "source": "https://github.com/container-interop/container-interop/tree/master"
-            },
-            "abandoned": "psr/container",
-            "time": "2017-02-14T19:40:03+00:00"
-        },
         {
             "name": "mindplay/testies",
             "version": "1.0.0",

--- a/src/Delegate.php
+++ b/src/Delegate.php
@@ -35,13 +35,13 @@ class Delegate implements RequestHandlerInterface
      */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        return call_user_func($this->callback, $request);
+        return ($this->callback)($request);
     }
 
     /**
      * Dispatch the next available middleware and return the response.
      *
-     * This method duplicates `next()` to provide backwards compatibility with non-PSR 15 middleware.
+     * This method duplicates `handle()` to provide support for `callable` middleware.
      *
      * @param ServerRequestInterface $request
      *
@@ -49,6 +49,6 @@ class Delegate implements RequestHandlerInterface
      */
     public function __invoke(ServerRequestInterface $request)
     {
-        return call_user_func($this->callback, $request);
+        return ($this->callback)($request);
     }
 }

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -26,9 +26,9 @@ class Dispatcher implements MiddlewareInterface, RequestHandlerInterface
     private $stack;
 
     /**
-     * @param (callable|MiddlewareInterface)[] $stack middleware stack (with at least one middleware component)
-     * @param callable|null $resolver optional middleware resolver:
-     *                                function (string $name): MiddlewareInterface
+     * @param (callable|MiddlewareInterface|mixed)[] $stack middleware stack (with at least one middleware component)
+     * @param callable|null $resolver optional middleware resolver function: receives an element from the
+     *                                middleware stack, resolves it and returns a `callable|MiddlewareInterface`
      *
      * @throws InvalidArgumentException if an empty middleware stack was given
      */
@@ -84,7 +84,7 @@ class Dispatcher implements MiddlewareInterface, RequestHandlerInterface
         if (isset($this->stack[$index])) {
             return new Delegate(function (ServerRequestInterface $request) use ($index) {
                 $middleware = $this->resolver
-                    ? call_user_func($this->resolver, $this->stack[$index])
+                    ? ($this->resolver)($this->stack[$index])
                     : $this->stack[$index]; // as-is
 
                 if ($middleware instanceof MiddlewareInterface) {

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -92,9 +92,10 @@ class Dispatcher implements MiddlewareInterface, RequestHandlerInterface
                 } else if (is_callable($middleware)) {
                     $result = $middleware($request, $this->resolve($index + 1));
                 } else {
-                    $given = readable::callback($middleware);
+                    $type = readable::typeof($middleware);
+                    $value = readable::value($middleware);
 
-                    throw new LogicException("unsupported middleware type: {$given}");
+                    throw new LogicException("unsupported middleware type: {$type} ({$value})");
                 }
 
                 if (! $result instanceof ResponseInterface) {

--- a/test/test.php
+++ b/test/test.php
@@ -1,20 +1,18 @@
 <?php
 
-use Interop\Container\ContainerInterface;
-use Interop\Http\Server\MiddlewareInterface as LegacyMiddlewareInterface;
 use mindplay\middleman\ContainerResolver;
 use mindplay\middleman\Dispatcher;
 use Nyholm\Psr7\Factory\Psr17Factory;
-use Psr\Container\ContainerInterface as PsrContainerInterface;
+use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Server\MiddlewareInterface as PsrMiddlewareInterface;
-use Psr\Http\Server\RequestHandlerInterface as RequestHandlerInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Http\Server\MiddlewareInterface;
 use function mindplay\testies\{ configure, test, run, ok, eq, expect };
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-configure()->enableCodeCoverage(__DIR__ . '/build/clover.xml', dirname(__DIR__) . '/src');
+configure()->enableCodeCoverage(__DIR__ . '/build/coverage.xml', dirname(__DIR__) . '/src');
 
 /**
  * @return ServerRequestInterface
@@ -36,7 +34,7 @@ test(
     'Throws for empty middleware stack',
     function () {
         expect(
-            'InvalidArgumentException',
+            InvalidArgumentException::class,
             'should throw for empty middleware stack',
             function () {
                 new Dispatcher([]);
@@ -55,7 +53,7 @@ test(
         ]);
 
         expect(
-            'LogicException',
+            LogicException::class,
             'should throw for exhausted middleware stack',
             function () use ($dispatcher) {
                 $dispatcher->handle(mock_server_request());
@@ -137,7 +135,7 @@ test(
                 return mock_response();
             }],
             function ($init) use (&$called, &$resolved) {
-                if (!is_string($init)) {
+                if (is_callable($init)) {
                     return $init;
                 }
 
@@ -186,7 +184,7 @@ test(
         $request = mock_server_request();
 
         expect(
-            'LogicException',
+            LogicException::class,
             'should throw on wrong return-type',
             function () use ($dispatcher, $request) {
                 $dispatcher->handle($request);
@@ -248,29 +246,12 @@ test(
         $dispatcher = new Dispatcher(['bar'], $resolver);
 
         expect(
-            'RuntimeException',
+            RuntimeException::class,
             'should throw for middleware that cannot be resolved',
             function () use ($dispatcher) {
                 $dispatcher->handle(mock_server_request());
             }
         );
-    }
-);
-
-class PsrMockContainer implements PsrContainerInterface
-{
-    public function get($id) {}
-    public function has($id) {}
-}
-
-test(
-    'can integrate with legacy container-interop',
-    function () {
-        $container = new PsrMockContainer();
-
-        $resolver = new ContainerResolver($container);
-
-        ok(true, "ContainerResolver constructor accepts a PSR container argument");
     }
 );
 
@@ -341,7 +322,7 @@ test(
     }
 );
 
-class LegacyServerMiddleware implements LegacyMiddlewareInterface
+class ServerMiddleware implements MiddlewareInterface
 {
     private $result;
 
@@ -357,38 +338,11 @@ class LegacyServerMiddleware implements LegacyMiddlewareInterface
 }
 
 test(
-    'can dispatch legacy PSR-15 server-middleware',
+    'can dispatch PSR-15 server-middleware',
     function () {
         $dispatcher = new Dispatcher([
-            new LegacyServerMiddleware(),
-            new LegacyServerMiddleware(mock_response())
-        ]);
-
-        ok($dispatcher->handle(mock_server_request()) instanceof ResponseInterface);
-    }
-);
-
-class PSRServerMiddleware implements PsrMiddlewareInterface
-{
-    private $result;
-
-    public function __construct($result = null)
-    {
-        $this->result = $result;
-    }
-
-    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
-    {
-        return $this->result ?: $handler->handle($request);
-    }
-}
-
-test(
-    'can dispatch final PSR-15 server-middleware',
-    function () {
-        $dispatcher = new Dispatcher([
-            new PSRServerMiddleware(),
-            new PSRServerMiddleware(mock_response())
+            new ServerMiddleware(),
+            new ServerMiddleware(mock_response())
         ]);
 
         ok($dispatcher->handle(mock_server_request()) instanceof ResponseInterface);

--- a/test/test.php
+++ b/test/test.php
@@ -63,6 +63,24 @@ test(
 );
 
 test(
+    'Throws for unsupported middleware type',
+    function () {
+        $dispatcher = new Dispatcher([
+            "foo",
+        ]);
+
+        expect(
+            LogicException::class,
+            'should throw for unsupported type',
+            function () use ($dispatcher) {
+                $dispatcher->handle(mock_server_request());
+            },
+            '/^unsupported middleware type: string \(\"foo\"\)$/'
+        );
+    }
+);
+
+test(
     'Can dispatch callable as middleware',
     function () {
         $called = false;


### PR DESCRIPTION
* remove support for legacy middleware and legacy IOC containers
* remove deprecated `dispatch()` method

Closes #17 
